### PR TITLE
Fix ingress creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Use the Eclipse Codewind sidecar plug-in for Eclipse Che to enable Theia to communicate with the Codewind server container.
 
 [![License](https://img.shields.io/badge/License-EPL%202.0-red.svg?label=license&logo=eclipse)](https://www.eclipse.org/legal/epl-2.0/)
+[![Chat](https://img.shields.io/static/v1.svg?label=chat&message=mattermost&color=145dbf)](https://mattermost.eclipse.org/eclipse/channels/eclipse-codewind)
 
 ## What is the Eclipse Codewind sidecar container?
 The Codewind sidecar container includes the following responsibilities:

--- a/codewind-che-sidecar/scripts/kube/deployPFE.sh
+++ b/codewind-che-sidecar/scripts/kube/deployPFE.sh
@@ -36,10 +36,8 @@ setTemplateValue $DEPLOY_DIR/codewind.yaml KUBE_NAMESPACE_PLACEHOLDER $NAMESPACE
 # Set the owner the Codewind deployment and service
 setCodewindOwner
 
-# Get the CHE_API url and extract the hostname component
-CHE_INGRESS_HOST=$(echo $CHE_API | sed -e 's#http[s]*://##') # remove protocol
-CHE_INGRESS_HOST=$(echo $CHE_INGRESS_HOST | sed -e 's#/.*##') # remove path
-sed -i "s/CHE_INGRESS_HOST_PLACEHOLDER/$CHE_INGRESS_HOST/g" /scripts/kube/codewind_template.yaml 
+# Set the ingress for Codewind
+setCodewindIngress
 
 # Check if we're on IBM Cloud Private and if so, apply the ibm-privileged-psp
 kubectl get images.icp.ibm.com

--- a/codewind-che-sidecar/scripts/kube/deployUtils.sh
+++ b/codewind-che-sidecar/scripts/kube/deployUtils.sh
@@ -108,3 +108,11 @@ function setCodewindOwner() {
     setTemplateValue $DEPLOY_DIR/codewind.yaml OWNER_REFERENCE_NAME_PLACEHOLDER $OWNER_REFERENCE_NAME
     setTemplateValue $DEPLOY_DIR/codewind.yaml OWNER_REFERENCE_UID_PLACEHOLDER $OWNER_REFERENCE_UID
 }
+
+function setCodewindIngress() {
+    # Get the CHE_API url and extract the hostname component
+    CHE_INGRESS_HOST=$(echo $CHE_API | sed -e 's#http[s]*://##') # remove protocol
+    CHE_INGRESS_HOST=$(echo $CHE_INGRESS_HOST | sed -e 's#/.*##') # remove path
+
+    setTemplateValue $DEPLOY_DIR/codewind.yaml CHE_INGRESS_HOST_PLACEHOLDER $CHE_INGRESS_HOST
+}

--- a/plugins/codewind/codewind-sidecar/latest/meta.yaml
+++ b/plugins/codewind/codewind-sidecar/latest/meta.yaml
@@ -25,7 +25,7 @@ latestUpdateDate: "2019-06-26"
 spec:
   containers:
   - name: codewind-che-sidecar
-    image: ibmcom/codewind-che-sidecar:latest
+    image: eclipse/codewind-che-sidecar:latest
     volumes:
       - mountPath: "/projects"
         name: projects

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -58,7 +58,7 @@ rules:
 
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
-  verbs: ["get", "patch"]
+  verbs: ["get", "list", "create", "delete", "watch"]
 
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
@@ -91,3 +91,7 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
+
+- apiGroups: ["route.openshift.io"]
+  resources: ["routes"]
+  verbs: ["get", "list", "create", "delete", "watch"]

--- a/setup/install_che/codewind-clusterrole.yaml
+++ b/setup/install_che/codewind-clusterrole.yaml
@@ -56,10 +56,6 @@ rules:
   resources: ["images"]
   verbs: ["get", "list", "create", "watch"]
 
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["get", "list", "create", "delete", "watch"]
-
 - apiGroups: ["apps", "extensions"]
   resources: ["deployments"]
   verbs: ["watch", "get", "list", "create", "update", "delete"]


### PR DESCRIPTION
* Pulls latest code from master
* Fixes a couple issues with roles and applying the Codewind yaml that prevented the ingress from being created

The ingress can now be created upon every build (provided the codewind clusterrole/rolebinding was created), but it complains about a 502 error. This may be because `/` in PFE returns a 404 status code rather than 200 (ingress requires `/` to return 200)